### PR TITLE
add `$bindable` prop `el` to `Pending_Button`

### DIFF
--- a/.changeset/large-zoos-jog.md
+++ b/.changeset/large-zoos-jog.md
@@ -1,0 +1,5 @@
+---
+"@ryanatkn/fuz": patch
+---
+
+add `focus` to the `Pending_Button` exported API

--- a/.changeset/large-zoos-jog.md
+++ b/.changeset/large-zoos-jog.md
@@ -1,5 +1,5 @@
 ---
-"@ryanatkn/fuz": patch
+'@ryanatkn/fuz': patch
 ---
 
-add `focus` to the `Pending_Button` exported API
+add `$bindable` prop `el` to `Pending_Button`

--- a/src/lib/Pending_Button.svelte
+++ b/src/lib/Pending_Button.svelte
@@ -10,27 +10,20 @@
 		title?: string;
 		disabled?: boolean;
 		attrs?: any;
+		el?: HTMLButtonElement | undefined;
 		children: Snippet;
 	}
 
-	const {pending, onclick, running, title, disabled, attrs, children}: Props = $props();
-
-	let el: HTMLButtonElement | undefined; // intentionally not `$state`, would need to use `untrack` in the helpers below if changed
-
-	/**
-	 * This API pattern is an experiment in contrast to exposing `el` through a bindable prop.
-	 * This is non-reactive, which I believe is generally what consumers want,
-	 * but this forces the issue which may cause issues.
-	 *
-	 * The initial motivation is to avoid grossness with `prefer-const` and `$props`,
-	 * which is admittedly not a good motivation to shape the API.
-	 * A better fix would be to have the ESLint plugin disable `prefer-const` for `$props`,
-	 * or perhaps that's something for the language tools to handle internally by, for example,
-	 * making each `$prop` a separate declaration that defaults to `const` for non-bindables.
-	 */
-	export const get_el = (): HTMLButtonElement | undefined => el;
-
-	export const focus = (): void => el?.focus();
+	let {
+		pending, // eslint-disable-line prefer-const
+		onclick, // eslint-disable-line prefer-const
+		running, // eslint-disable-line prefer-const
+		title, // eslint-disable-line prefer-const
+		disabled, // eslint-disable-line prefer-const
+		attrs, // eslint-disable-line prefer-const
+		el = $bindable(),
+		children, // eslint-disable-line prefer-const
+	}: Props = $props();
 
 	// TODO maybe this shouldn't disable? just visually look disabled, maybe with `.disabled`?
 	// TODO cancelable?

--- a/src/lib/Pending_Button.svelte
+++ b/src/lib/Pending_Button.svelte
@@ -25,6 +25,8 @@
 		children, // eslint-disable-line prefer-const
 	}: Props = $props();
 
+	el; // TODO @see https://github.com/sveltejs/language-tools/issues/2268
+
 	// TODO maybe this shouldn't disable? just visually look disabled, maybe with `.disabled`?
 	// TODO cancelable?
 </script>

--- a/src/lib/Pending_Button.svelte
+++ b/src/lib/Pending_Button.svelte
@@ -15,14 +15,20 @@
 
 	const {pending, onclick, running, title, disabled, attrs, children}: Props = $props();
 
+	let el: HTMLButtonElement | undefined; // intentionally not `$state`, would need to use `untrack` in the helpers below if changed
+
 	/**
 	 * This API pattern is an experiment in contrast to exposing `el` through a bindable prop.
-	 * The prop exposes more API surface area than is usually necessary,
-	 * and although I'm inclined to give consumers more control,
-	 * this also avoids some grossness with the ESLint `prefer-const` rule.
-	 * (that's a poor reason to shape the API though, hence why I'm calling it an experiment)
+	 * This is non-reactive, which I believe is generally what consumers want,
+	 * but this forces the issue which may cause issues.
+	 *
+	 * The initial motivation is to avoid grossness with `prefer-const` and `$props`,
+	 * which is admittedly not a good motivation to shape the API.
+	 * A better fix would be to have the ESLint plugin disable `prefer-const` for `$props`,
+	 * or perhaps that's something for the language tools to handle internally by, for example,
+	 * making each `$prop` a separate declaration that defaults to `const` for non-bindables.
 	 */
-	let el: HTMLButtonElement | undefined;
+	export const get_el = (): HTMLButtonElement | undefined => el;
 
 	export const focus = (): void => el?.focus();
 

--- a/src/lib/Pending_Button.svelte
+++ b/src/lib/Pending_Button.svelte
@@ -13,12 +13,32 @@
 		children: Snippet;
 	}
 
-	// TODO maybe this shouldn't disable? cancelable?
-
 	const {pending, onclick, running, title, disabled, attrs, children}: Props = $props();
+
+	/**
+	 * This API pattern is an experiment in contrast to exposing `el` through a bindable prop.
+	 * The prop exposes more API surface area than is usually necessary,
+	 * and although I'm inclined to give consumers more control,
+	 * this also avoids some grossness with the ESLint `prefer-const` rule.
+	 * (that's a poor reason to shape the API though, hence why I'm calling it an experiment)
+	 */
+	let el: HTMLButtonElement | undefined;
+
+	export const focus = (): void => el?.focus();
+
+	// TODO maybe this shouldn't disable? just visually look disabled, maybe with `.disabled`?
+	// TODO cancelable?
 </script>
 
-<button type="button" {...attrs} disabled={disabled ?? pending} {title} class:pending {onclick}>
+<button
+	bind:this={el}
+	type="button"
+	{...attrs}
+	disabled={disabled ?? pending}
+	{title}
+	class:pending
+	{onclick}
+>
 	<span class="content">
 		{@render children()}
 	</span>


### PR DESCRIPTION
There's a couple of gross workarounds here, one of which should be fixed (`el;`) and the other could likely be fixed in the Svelte ESLint plugin or Svelte itself. (all the `// eslint-disable-line prefer-const`, a recurring wart with the rule and Svelte 5)