### PR TITLE
remove `el` from `Pending_Button` props in favor of an exported `focus` method

### DIFF
--- a/.changeset/dirty-onions-melt.md
+++ b/.changeset/dirty-onions-melt.md
@@ -1,5 +1,5 @@
 ---
-"@ryanatkn/fuz": patch
+'@ryanatkn/fuz': minor
 ---
 
 remove `el` from `Pending_Button` props in favor of an exported `focus` method

--- a/.changeset/dirty-onions-melt.md
+++ b/.changeset/dirty-onions-melt.md
@@ -1,0 +1,5 @@
+---
+"@ryanatkn/fuz": patch
+---
+
+remove `el` from `Pending_Button` props in favor of an exported `focus` method

--- a/src/lib/Pending_Button.svelte
+++ b/src/lib/Pending_Button.svelte
@@ -21,7 +21,6 @@
 	export const focus = (options?: FocusOptions | undefined): void => el?.focus(options);
 
 	// TODO maybe this shouldn't disable? just visually look disabled, maybe with `.disabled`?
-	// TODO cancelable?
 </script>
 
 <button

--- a/src/lib/Pending_Button.svelte
+++ b/src/lib/Pending_Button.svelte
@@ -18,7 +18,7 @@
 
 	let el: HTMLButtonElement | undefined; // intentionally not reactive
 
-	const focus = (options?: FocusOptions | undefined): void => el?.focus(options);
+	export const focus = (options?: FocusOptions | undefined): void => el?.focus(options);
 
 	// TODO maybe this shouldn't disable? just visually look disabled, maybe with `.disabled`?
 </script>

--- a/src/lib/Pending_Button.svelte
+++ b/src/lib/Pending_Button.svelte
@@ -18,7 +18,7 @@
 
 	let el: HTMLButtonElement | undefined; // intentionally not reactive
 
-	export const focus = (options?: FocusOptions | undefined): void => el?.focus(options);
+	const focus = (options?: FocusOptions | undefined): void => el?.focus(options);
 
 	// TODO maybe this shouldn't disable? just visually look disabled, maybe with `.disabled`?
 </script>

--- a/src/lib/Pending_Button.svelte
+++ b/src/lib/Pending_Button.svelte
@@ -14,18 +14,11 @@
 		children: Snippet;
 	}
 
-	let {
-		pending, // eslint-disable-line prefer-const
-		onclick, // eslint-disable-line prefer-const
-		running, // eslint-disable-line prefer-const
-		title, // eslint-disable-line prefer-const
-		disabled, // eslint-disable-line prefer-const
-		attrs, // eslint-disable-line prefer-const
-		el = $bindable(),
-		children, // eslint-disable-line prefer-const
-	}: Props = $props();
+	const {pending, onclick, running, title, disabled, attrs, children}: Props = $props();
 
-	el; // TODO @see https://github.com/sveltejs/language-tools/issues/2268
+	let el: HTMLButtonElement | undefined; // intentionally not reactive
+
+	export const focus = (options?: FocusOptions | undefined): void => el?.focus(options);
 
 	// TODO maybe this shouldn't disable? just visually look disabled, maybe with `.disabled`?
 	// TODO cancelable?

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -4,6 +4,7 @@ import adapter from '@sveltejs/adapter-static';
 /** @type {import('@sveltejs/kit').Config} */
 export default {
 	preprocess: [vitePreprocess()],
+	compilerOptions: {runes: true},
 	// TODO ideally this would use the default but it conflicts with ctrl+shift+c in Chrome,
 	// but it's strange to me that I'm resetting it to what the Mac default is
 	vitePlugin: {inspector: {toggleKeyCombo: 'meta-shift'}}, // docs: https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/inspector.md

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -4,7 +4,8 @@ import adapter from '@sveltejs/adapter-static';
 /** @type {import('@sveltejs/kit').Config} */
 export default {
 	preprocess: [vitePreprocess()],
-	compilerOptions: {runes: true},
+	// TODO enable
+	// compilerOptions: {runes: true},
 	// TODO ideally this would use the default but it conflicts with ctrl+shift+c in Chrome,
 	// but it's strange to me that I'm resetting it to what the Mac default is
 	vitePlugin: {inspector: {toggleKeyCombo: 'meta-shift'}}, // docs: https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/inspector.md


### PR DESCRIPTION
Reverts #28 in favor of a different API. I'm thinking I'll prefer more constrained component APIs instead of exposing elements through bindable props, so consumers should bind to the component instead.

A downside is it's less flexible, but I think we want explicit API in general instead of exposing elements to consumers as a general rule.

Another downside is the boilerplate of proxying all of the desired methods on the wrapped elements.