### PR TITLE
remove classes from props interfaces for attrs

### DIFF
--- a/.changeset/itchy-toes-warn.md
+++ b/.changeset/itchy-toes-warn.md
@@ -1,0 +1,5 @@
+---
+'@ryanatkn/fuz': patch
+---
+
+add `Paste_From_Clipboard`

--- a/.changeset/mighty-dolls-travel.md
+++ b/.changeset/mighty-dolls-travel.md
@@ -1,0 +1,5 @@
+---
+"@ryanatkn/fuz": minor
+---
+
+remove classes from props interfaces for attrs

--- a/.changeset/proud-pandas-impress.md
+++ b/.changeset/proud-pandas-impress.md
@@ -1,0 +1,5 @@
+---
+'@ryanatkn/fuz': minor
+---
+
+improve `Copy_To_Clipboard` to pass a status to children

--- a/.changeset/proud-pandas-impress.md
+++ b/.changeset/proud-pandas-impress.md
@@ -2,4 +2,7 @@
 '@ryanatkn/fuz': minor
 ---
 
-improve `Copy_To_Clipboard` to pass a status to children
+update
+
+- change `Copy_To_Clipboard` to pass a status to children
+- change `onclick` to `oncopy`

--- a/package.json
+++ b/package.json
@@ -282,6 +282,11 @@
       "svelte": "./dist/Package_Summary.svelte",
       "default": "./dist/Package_Summary.svelte"
     },
+    "./Paste_From_Clipboard.svelte": {
+      "types": "./dist/Paste_From_Clipboard.svelte.d.ts",
+      "svelte": "./dist/Paste_From_Clipboard.svelte",
+      "default": "./dist/Paste_From_Clipboard.svelte"
+    },
     "./Pending_Animation.svelte": {
       "types": "./dist/Pending_Animation.svelte.d.ts",
       "svelte": "./dist/Pending_Animation.svelte",

--- a/src/lib/Copy_To_Clipboard.svelte
+++ b/src/lib/Copy_To_Clipboard.svelte
@@ -5,14 +5,13 @@
 	interface Props {
 		text: string | null;
 		onclick?: (text: string | null, e: MouseEvent) => void;
-		classes?: string;
 		attrs?: SvelteHTMLElements['button'];
 		children?: Snippet<[copied: boolean, failed: boolean]>;
 	}
 
 	// TODO add library entry
 
-	const {text, onclick, classes, attrs, children}: Props = $props();
+	const {text, onclick, attrs, children}: Props = $props();
 
 	let copied = $state(false);
 	let failed = $state(false);
@@ -53,7 +52,7 @@
 	type="button"
 	title="copy to clipboard"
 	{...attrs}
-	class={classes ?? (children ? undefined : 'icon_button size_lg')}
+	class={attrs?.class ?? (children ? undefined : 'icon_button size_lg')}
 	class:copied
 	class:failed
 	onclick={copy}

--- a/src/lib/Copy_To_Clipboard.svelte
+++ b/src/lib/Copy_To_Clipboard.svelte
@@ -5,14 +5,14 @@
 
 	interface Props {
 		text: string | null;
-		onclick?: (text: string | null, e: MouseEvent) => void;
+		oncopy?: (text: string | null, e: MouseEvent) => void;
 		attrs?: SvelteHTMLElements['button'];
 		children?: Snippet<[status: Async_Status]>;
 	}
 
-	// TODO add library entry
+	// TODO add library entry, see also Paste_From_Clipboard.svelte
 
-	const {text, onclick, attrs, children}: Props = $props();
+	const {text, oncopy, attrs, children}: Props = $props();
 
 	let status: Async_Status = $state('initial');
 
@@ -29,10 +29,10 @@
 			status = 'success';
 		} catch (_err) {
 			status = 'failure';
-			onclick?.(null, e);
+			oncopy?.(null, e);
 			return;
 		}
-		onclick?.(text, e);
+		oncopy?.(text, e);
 	};
 
 	const disabled = $derived(attrs?.disabled ?? text === null);

--- a/src/lib/Mdn_Link.svelte
+++ b/src/lib/Mdn_Link.svelte
@@ -32,5 +32,5 @@
 	{:else}
 		{@render final_children()}
 	{/if}
-	<Svg data={mdn_logo} inline size="var(--icon_size_xs)" classes="mx_xs3" /></a
+	<Svg data={mdn_logo} inline size="var(--icon_size_xs)" attrs={{class: 'mx_xs3'}} /></a
 >

--- a/src/lib/Paste_From_Clipboard.svelte
+++ b/src/lib/Paste_From_Clipboard.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type {Snippet} from 'svelte';
+	import type {SvelteHTMLElements} from 'svelte/elements';
+
+	interface Props {
+		onpaste: (text: string) => void;
+		attrs?: SvelteHTMLElements['button'];
+		children?: Snippet;
+	}
+	const {onpaste, attrs, children}: Props = $props();
+
+	// TODO add library entry, see also Copy_To_Clipboard.svelte
+</script>
+
+<button
+	type="button"
+	{...attrs}
+	onclick={async () => {
+		const text = await navigator.clipboard.readText();
+		onpaste(text);
+	}}
+>
+	{#if children}{@render children()}{:else}paste{/if}
+</button>

--- a/src/lib/Svg.svelte
+++ b/src/lib/Svg.svelte
@@ -50,22 +50,10 @@
 		 * Flex shrink behavior? Defaults to `true`.
 		 */
 		shrink?: boolean;
-		classes?: string;
 		attrs?: SvelteHTMLElements['svg'];
 	}
 
-	const {
-		data,
-		fill,
-		size,
-		width,
-		height,
-		label,
-		inline,
-		shrink = true,
-		classes,
-		attrs,
-	}: Props = $props();
+	const {data, fill, size, width, height, label, inline, shrink = true, attrs}: Props = $props();
 
 	const final_fill = $derived(fill ?? data.fill ?? 'var(--text_color, #000)'); // can be overridden by each path's `fill` attribute
 	const final_width = $derived(width ?? size); // TODO @many default value? `100%` or omitted or something else?
@@ -87,7 +75,6 @@
 	{style}
 	style:width={final_width}
 	style:height={final_height}
-	class={classes}
 	class:inline
 	style:flex-shrink={shrink ? 1 : 0}
 >

--- a/src/routes/Style_Variable_Button.svelte
+++ b/src/routes/Style_Variable_Button.svelte
@@ -7,14 +7,13 @@
 
 	interface Props {
 		name: string; // TODO type? generate from `tomes`? or keep extensible?
-		classes?: string;
 		inline?: boolean;
 		plain?: boolean;
 		attrs?: SvelteHTMLElements['button'];
 		children?: Snippet;
 	}
 
-	const {name, classes, inline = false, plain = true, attrs, children}: Props = $props();
+	const {name, inline = false, plain = true, attrs, children}: Props = $props();
 
 	// TODO @many add to $lib?
 
@@ -32,7 +31,6 @@
 <button
 	type="button"
 	{...attrs}
-	class={classes}
 	class:inline
 	class:plain
 	onclick={() => (selected_variable.value = variable)}

--- a/src/routes/package.ts
+++ b/src/routes/package.ts
@@ -246,6 +246,11 @@ export const package_json = {
 			svelte: './dist/Package_Summary.svelte',
 			default: './dist/Package_Summary.svelte',
 		},
+		'./Paste_From_Clipboard.svelte': {
+			types: './dist/Paste_From_Clipboard.svelte.d.ts',
+			svelte: './dist/Paste_From_Clipboard.svelte',
+			default: './dist/Paste_From_Clipboard.svelte',
+		},
 		'./Pending_Animation.svelte': {
 			types: './dist/Pending_Animation.svelte.d.ts',
 			svelte: './dist/Pending_Animation.svelte',
@@ -446,6 +451,7 @@ export const src_json = {
 		'./Mdn_Link.svelte': {path: 'Mdn_Link.svelte', declarations: []},
 		'./Package_Detail.svelte': {path: 'Package_Detail.svelte', declarations: []},
 		'./Package_Summary.svelte': {path: 'Package_Summary.svelte', declarations: []},
+		'./Paste_From_Clipboard.svelte': {path: 'Paste_From_Clipboard.svelte', declarations: []},
 		'./Pending_Animation.svelte': {path: 'Pending_Animation.svelte', declarations: []},
 		'./Pending_Button.svelte': {path: 'Pending_Button.svelte', declarations: []},
 		'./Project_Links.svelte': {path: 'Project_Links.svelte', declarations: []},


### PR DESCRIPTION
Duplicating `classes` on top of `attrs` is confusing and not useful. Attributes in Svelte 5 are more powerful because more things like events are spreadable, so centering on them makes sense.